### PR TITLE
Give core-toolbar a default background color

### DIFF
--- a/core-toolbar.css
+++ b/core-toolbar.css
@@ -17,6 +17,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   height: 64px;
   /* typography */
   font-size: 1.3em;
+  /* background */
+  background-color: #CFD8DC;
 }
 
 :host(.animate) {


### PR DESCRIPTION
I'd like to add a default grey background color to core-toolbar so it's very clear to a new user that they have successfully added one to their page. Right now, core-toolbar is transparent, which can initially lead people to think that they've messed something up when they just get a blank screen. I realize this may mean going back to some of our demos which rely on the transparent behavior of core-toolbar and updating them to specifically not have a background, but I think/hope the trade-off is worth it for the increased feedback to new users.
