### PR TITLE
Fix some comment grammar typos in core-toolbar

### DIFF
--- a/core-toolbar.html
+++ b/core-toolbar.html
@@ -17,14 +17,14 @@ label, navigation, search and actions.
       <core-icon-button icon="more" on-tap="{{moreAction}}"></core-icon-button>
     </core-toolbar>
 
-`core-toolbar` has a standard height, but can be taller by setting `tall`
-class on the `core-toolbar`.  The will make the toolbar 3x the normal height.
+`core-toolbar` has a standard height, but can made be taller by setting `tall`
+class on the `core-toolbar`.  This will make the toolbar 3x the normal height.
 
     <core-toolbar class="tall">
       <core-icon-button icon="menu"></core-icon-button>
     </core-toolbar>
     
-Apply `medium-tall` class to make the toolbar medium tall.  The will make the 
+Apply `medium-tall` class to make the toolbar medium tall.  This will make the 
 toolbar 2x the normal height.
 
     <core-toolbar class="medium-tall">
@@ -39,7 +39,7 @@ When taller, elements can pin to either the top (default), middle or bottom.
       <div class="bottom indent">Bottom Title</div>
     </core-toolbar>
     
-To make an element completely fits at the bottom of the toolbar, use `fit` along
+To make an element completely fit at the bottom of the toolbar, use `fit` along
 with `bottom`.
 
     <core-toolbar class="tall">


### PR DESCRIPTION
Ran into some grammar typos in the comments when perusing the code.
