### PR TITLE
fix small bug in new justify attributes

### DIFF
--- a/core-toolbar.html
+++ b/core-toolbar.html
@@ -36,7 +36,9 @@ toolbar 2x the normal height.
       <core-icon-button icon="menu"></core-icon-button>
     </core-toolbar>
 
-When taller, items can pin to either the top (default), middle or bottom.
+When taller, items can pin to either the top (default), middle or bottom. When
+using `medium-tall`, the middle and bottom divs overlap, but middleJustify and
+bottomJustify attributes are still honored separately.
 
     <core-toolbar class="tall">
       <core-icon-button icon="menu"></core-icon-button>
@@ -122,11 +124,11 @@ on itself or any of its ancestors.
     },
     
     middleJustifyChanged: function(old) {
-      this.updateBarJustify(this.$.middleBar, this.justify, old);
+      this.updateBarJustify(this.$.middleBar, this.middleJustify, old);
     },
     
     bottomJustifyChanged: function(old) {
-      this.updateBarJustify(this.$.bottomBar, this.justify, old);
+      this.updateBarJustify(this.$.bottomBar, this.bottomJustify, old);
     },
     
     updateBarJustify: function(bar, justify, old) {


### PR DESCRIPTION
When the `justify`, `middleJustify`, and `bottomJustify` attributes were added, all three changed watchers were using `this.justify` instead of their respective attributes, so only one justify style would be applied to all three divs.  This has been corrected.  Also, some new verbiage was added to the comments at the top of the file to indicate a difference between `tall` and `medium-tall` class behavior.
