### PR TITLE
Allow disabled buttons to have no pointer-events

### DIFF
--- a/core-toolbar.css
+++ b/core-toolbar.css
@@ -93,6 +93,12 @@ polyfill-next-selector { content: '.toolbar-tools > *'; }
   pointer-events: auto;
 }
 
+/* When elements are disabled, disable the pointer-events. */
+polyfill-next-selector { content: '.toolbar-tools > *'; }
+::content > *[disabled] {
+  pointer-events: none;
+}
+
 /* elements spacing */
 polyfill-next-selector { content: '.toolbar-tools > *'; }
 ::content > * {


### PR DESCRIPTION
Before, disabled paper-icon-button and core-icon-button still received
pointer-events. See Gist https://gist.github.com/MetaMemoryT/17c216c4a45add089f9e#file-buttons-in-core-toolbar-disabled-noclick-html for a demonstration.  The Gist also includes some style rules to work around the existing implementation.

The problem is that this rule:

```
/* make elements (e.g. buttons) respond to mouse/touch events */
polyfill-next-selector { content: '.toolbar-tools > *'; }
::content > * {
  pointer-events: auto;
}
```

Overides the rule declared in core-icon-button.css which is:

```
:host([disabled]) {
  opacity: 0.6;
  pointer-events: none;
}
```

Because :host is least specific.
