### PR TITLE
.toolbar-tools's height need to be inherit.

### DIFF
--- a/core-toolbar.css
+++ b/core-toolbar.css
@@ -36,7 +36,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 .toolbar-tools {
   position: relative;
-  height: 64px;
+  height: inherit;
   padding: 0 8px;
   pointer-events: none;
 }


### PR DESCRIPTION
If I need to change height of toolbar, In current scenario - we need to address 2 targets.

```
core-toolbar,
core-toolbar /deep/ .toolbar-tools {
  height: 50px;
}
```

its better to go with `inherit`.
