### PR TITLE
Fixed bottomJustify and middleJustify updates

### DIFF
--- a/core-toolbar.html
+++ b/core-toolbar.html
@@ -138,7 +138,7 @@ on itself or any of its ancestors.
       if (old) {
         bar.removeAttribute(this.toLayoutAttrName(old));
       }
-      if (this.justify) {
+      if (justify) {
         bar.setAttribute(this.toLayoutAttrName(justify), '');
       }
     },


### PR DESCRIPTION
In `updateBarJustify`, instead of the input parameter `justify`, the element's `this.justify` attribute was checked, preventing the attributes for `bottomJustify` and `middleJustify` from being updated. This complements fix #12.
