### PR TITLE
Icon "more" does not exist anymore.

### DIFF
--- a/core-toolbar.html
+++ b/core-toolbar.html
@@ -19,7 +19,7 @@ Example:
     <core-toolbar>
       <core-icon-button icon="menu" on-tap="{{menuAction}}"></core-icon-button>
       <div flex>Title</div>
-      <core-icon-button icon="more" on-tap="{{moreAction}}"></core-icon-button>
+      <core-icon-button icon="more-vert" on-tap="{{moreAction}}"></core-icon-button>
     </core-toolbar>
 
 `core-toolbar` has a standard height, but can made be taller by setting `tall`


### PR DESCRIPTION
Renamed example to more-vert which is the intended behavior.