### PR TITLE
Move computed props to template where not needed

### DIFF
--- a/core-toolbar.html
+++ b/core-toolbar.html
@@ -157,15 +157,15 @@ still honored separately.
 
   <template>
 
-    <div id="bottomBar" class-name="[[_bottomBarClassName]]">
+    <div id="bottomBar" class-name="[[_computeBarClassName(bottomJustify)]]">
       <content select=".bottom"></content>
     </div>
 
-    <div id="middleBar" class-name="[[_middleBarClassName]]">
+    <div id="middleBar" class-name="[[_computeBarClassName(middleJustify)]]">
       <content select=".middle"></content>
     </div>
 
-    <div id="topBar" class-name="[[_topBarClassName]]">
+    <div id="topBar" class-name="[[_computeBarClassName(justify)]]">
       <content></content>
     </div>
 
@@ -235,23 +235,11 @@ still honored separately.
         middleJustify: {
           type: String,
           value: ''
-        },
-
-        _bottomBarClassName: {
-          computed: 'computeBarClassName(bottomJustify)'
-        },
-
-        _middleBarClassName: {
-          computed: 'computeBarClassName(middleJustify)'
-        },
-
-        _topBarClassName: {
-          computed: 'computeBarClassName(justify)'
         }
 
       },
 
-      computeBarClassName: function(barJustify) {
+      _computeBarClassName: function(barJustify) {
         var classObj = {
           center: true,
           horizontal: true,


### PR DESCRIPTION
Because the return values of all of the `computeX` functions were
written to the DOM and then tossed, the method calls can live in the DOM
to reduce the `computed: 'xyz()'` boilerplate without sacrificing
legibility.
